### PR TITLE
fix spawn bug

### DIFF
--- a/src/utils/logic.ts
+++ b/src/utils/logic.ts
@@ -96,7 +96,7 @@ const moveRowLeft = (row: Cell[]): { result: Cell[]; isMoved: boolean } => {
 
   return {
     result: resultRow,
-    isMoved: row.some((cell, i) => cell !== result[i]),
+    isMoved: row.some((cell, i) => cell != result[i]), // 0과 null은 같음으로 취급해야하므로 !==대신 != 연산자 사용
   };
 };
 


### PR DESCRIPTION
null에서 0으로 변하거나 0에서 null로 변하더라도 `isMoved` `true`가 리턴된다. 이 경우 `false`가 리턴되도록 수정하였다.